### PR TITLE
v0.1.38

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,16 +1,16 @@
 {
   "name": "avalanchego.avado.dnp.dappnode.eth",
-  "version": "0.1.37",
-  "upstream": "v1.2.1",
+  "version": "0.1.38",
+  "upstream": "v1.2.2",
   "title": "Avalanche node",
   "description": "This is the Avalanche Mainnet node. Avalanche is an open-source platform for launching highly decentralized applications, new financial primitives, and new interoperable blockchains.",
   "avatar": "/ipfs/QmVwkdxaKfTiv6apuHjVP2ftzPahpcmwHpBNNdKp8QzZPn",
   "type": "service",
   "autoupdate": true,
   "image": {
-    "path": "avalanchego.avado.dnp.dappnode.eth_0.1.37.tar.xz",
-    "hash": "/ipfs/QmcoD8zUtktZMxVrdSUqZoANR6sx4YydsFRTeDTXjWfv5w",
-    "size": 248846140,
+    "path": "avalanchego.avado.dnp.dappnode.eth_0.1.38.tar.xz",
+    "hash": "/ipfs/QmWaUVo5pSYV3y57pefp1kFKLNN27EweZX9GhR3UWmZ7Tk",
+    "size": 246153860,
     "restart": "always",
     "environment": [
       "EXTRA_OPTS"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,11 @@
 version: '3.4'
 services:
   avalanchego.avado.dnp.dappnode.eth:
-    image: 'avalanchego.avado.dnp.dappnode.eth:0.1.37'
+    image: 'avalanchego.avado.dnp.dappnode.eth:0.1.38'
     build:
       context: ./build
       args:
-        - VERSION=v1.2.1
+        - VERSION=v1.2.2
     environment:
       - EXTRA_OPTS=--dynamic-public-ip=opendns
     volumes:

--- a/releases.json
+++ b/releases.json
@@ -171,5 +171,12 @@
     "uploadedTo": {
       "http://80.208.229.228:5001": "Sat, 27 Feb 2021 08:40:26 GMT"
     }
+  },
+  "0.1.38": {
+    "hash": "/ipfs/QmUArC6eVytAmq48dMZLPAP679FGqUA2dehoch3gp9c75L",
+    "type": "manifest",
+    "uploadedTo": {
+      "http://80.208.229.228:5001": "Sat, 06 Mar 2021 21:45:03 GMT"
+    }
   }
 }


### PR DESCRIPTION
Manifest Hash: /ipfs/QmUArC6eVytAmq48dMZLPAP679FGqUA2dehoch3gp9c75L

---

Avado Avalanche v0.1.38 Release Notes;
The Avalanche version is updated to v1.2.2. This update features stability, performance and monitoring improvements.

News in Avalanche v1.2.2;
* Added IP aliases in the network library to avoid repeated SYN calls.
* Fixed bootstrap message handling when bootstrapping from yourself.
* Simplified AdvanceTimeTx issuance.
* Added new consensus health checks.
* Adding node health logging.
* Added health responses to health GET requests.
* Consolidated incoming message logs.
* Added error logging to the LevelDB wrapper.
* Added error codes to the rpcdb to avoid string parsing.
* Improved C-chain handling of canonical chain to reduce the number of reorgs.
* Improved C-chain handling of mock calls performed on the pending block.