### PR TITLE
v0.1.39

### DIFF
--- a/build/files/nginx.conf
+++ b/build/files/nginx.conf
@@ -33,8 +33,23 @@ http {
 
   server {
     listen            443 ssl;
-    ssl_certificate /etc/nginx/certs/server.crt;  
+    ssl_certificate /etc/nginx/certs/server.crt;
     ssl_certificate_key /etc/nginx/certs/server.key;
+
+    # needed for /api/price
+    proxy_ssl_server_name on;
+
+    location /api/price {
+        proxy_set_header Host wallet.avax.network;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Host-Real-IP  $http_host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+        proxy_pass https://wallet.avax.network;
+        proxy_read_timeout 90;
+    }
 
     location / {
         root /usr/local/wallet;

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,16 +1,16 @@
 {
   "name": "avalanchego.avado.dnp.dappnode.eth",
-  "version": "0.1.38",
-  "upstream": "v1.2.2",
+  "version": "0.1.39",
+  "upstream": "v1.2.3",
   "title": "Avalanche node",
   "description": "This is the Avalanche Mainnet node. Avalanche is an open-source platform for launching highly decentralized applications, new financial primitives, and new interoperable blockchains.",
   "avatar": "/ipfs/QmVwkdxaKfTiv6apuHjVP2ftzPahpcmwHpBNNdKp8QzZPn",
   "type": "service",
   "autoupdate": true,
   "image": {
-    "path": "avalanchego.avado.dnp.dappnode.eth_0.1.38.tar.xz",
-    "hash": "/ipfs/QmWW61y44ir9PazAVqYdfmpc96pHvbWSgaViQ9SyyrVxv5",
-    "size": 248396584,
+    "path": "avalanchego.avado.dnp.dappnode.eth_0.1.39.tar.xz",
+    "hash": "/ipfs/QmfQHegygGMa4ap7YQ4Mbmxr3FAwnfbgdEM4tYHE7EjiNU",
+    "size": 249700896,
     "restart": "always",
     "environment": [
       "EXTRA_OPTS"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,11 @@
 version: '3.4'
 services:
   avalanchego.avado.dnp.dappnode.eth:
-    image: 'avalanchego.avado.dnp.dappnode.eth:0.1.38'
+    image: 'avalanchego.avado.dnp.dappnode.eth:0.1.39'
     build:
       context: ./build
       args:
-        - VERSION=v1.2.2
+        - VERSION=v1.2.3
     environment:
       - EXTRA_OPTS=--dynamic-public-ip=opendns
     volumes:

--- a/releases.json
+++ b/releases.json
@@ -179,5 +179,12 @@
     "uploadedTo": {
       "dappnode": "Sun, 07 Mar 2021 21:43:51 GMT"
     }
+  },
+  "0.1.39": {
+    "hash": "/ipfs/QmQoH6NetaVJPfLJ7NU5CJYxeRwmLb7mUGRFGDnS2RTu5X",
+    "type": "manifest",
+    "uploadedTo": {
+      "http://80.208.229.228:5001": "Tue, 09 Mar 2021 17:48:11 GMT"
+    }
   }
 }


### PR DESCRIPTION
Hash: /ipfs/QmQoH6NetaVJPfLJ7NU5CJYxeRwmLb7mUGRFGDnS2RTu5X

---

Avado Avalanche v0.1.39 Release Notes;
The Avalanche version is updated to v1.2.3. Also, the spinning wheel bug while displaying balance is fixed.

News in Avalanche v1.2.3;
* Adjusted [network, router, consensus] health check parameters to remove flaky health checks.
* Simplified C-chain block handling.
