### PR TITLE
v0.1.41

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,16 +1,16 @@
 {
   "name": "avalanchego.avado.dnp.dappnode.eth",
-  "version": "0.1.40",
-  "upstream": "v1.2.3",
+  "version": "0.1.41",
+  "upstream": "v1.2.4",
   "title": "Avalanche node",
   "description": "This is the Avalanche Mainnet node. Avalanche is an open-source platform for launching highly decentralized applications, new financial primitives, and new interoperable blockchains.",
   "avatar": "/ipfs/QmVwkdxaKfTiv6apuHjVP2ftzPahpcmwHpBNNdKp8QzZPn",
   "type": "service",
   "autoupdate": true,
   "image": {
-    "path": "avalanchego.avado.dnp.dappnode.eth_0.1.40.tar.xz",
-    "hash": "/ipfs/Qme5fYGRCnLdRQXwAQTgsajhEuJQqtyAjTSHyLG4iu4DT1",
-    "size": 250397344,
+    "path": "avalanchego.avado.dnp.dappnode.eth_0.1.41.tar.xz",
+    "hash": "/ipfs/QmfBHgGQg2vLrTJ53Gr7DqixLNyiAFxKdy4tH1CuD1rgud",
+    "size": 247333904,
     "restart": "always",
     "environment": [
       "EXTRA_OPTS"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,11 @@
 version: '3.4'
 services:
   avalanchego.avado.dnp.dappnode.eth:
-    image: 'avalanchego.avado.dnp.dappnode.eth:0.1.40'
+    image: 'avalanchego.avado.dnp.dappnode.eth:0.1.41'
     build:
       context: ./build
       args:
-        - VERSION=v1.2.3
+        - VERSION=v1.2.4
     environment:
       - EXTRA_OPTS=--dynamic-public-ip=opendns
     volumes:

--- a/releases.json
+++ b/releases.json
@@ -193,5 +193,12 @@
     "uploadedTo": {
       "http://80.208.229.228:5001": "Tue, 09 Mar 2021 22:51:30 GMT"
     }
+  },
+  "0.1.41": {
+    "hash": "/ipfs/QmYVeCxS39WSYXNfQ7TbxERj6Z5QJWTXghaT3yjx7Papwo",
+    "type": "manifest",
+    "uploadedTo": {
+      "http://80.208.229.228:5001": "Thu, 18 Mar 2021 17:17:27 GMT"
+    }
   }
 }


### PR DESCRIPTION
Hash: /ipfs/QmYVeCxS39WSYXNfQ7TbxERj6Z5QJWTXghaT3yjx7Papwo

---

Avado Avalanche v0.1.41 Release Notes;
The Avalanche version is updated to v1.2.4.

News in Avalanche v1.2.4;
- Added additional error handling to Avalanche Tx verification during bootstrapping.
- Updated numerous metrics, including adding various new metrics relating to node health and database usage, removing unused and invalid metrics, and fixing some metric names.