### PR TITLE
v0.1.42

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,16 +1,16 @@
 {
   "name": "avalanchego.avado.dnp.dappnode.eth",
-  "version": "0.1.41",
-  "upstream": "v1.2.4",
+  "version": "0.1.42",
+  "upstream": "v1.3.0",
   "title": "Avalanche node",
   "description": "This is the Avalanche Mainnet node. Avalanche is an open-source platform for launching highly decentralized applications, new financial primitives, and new interoperable blockchains.",
   "avatar": "/ipfs/QmVwkdxaKfTiv6apuHjVP2ftzPahpcmwHpBNNdKp8QzZPn",
   "type": "service",
   "autoupdate": true,
   "image": {
-    "path": "avalanchego.avado.dnp.dappnode.eth_0.1.41.tar.xz",
-    "hash": "/ipfs/QmfBHgGQg2vLrTJ53Gr7DqixLNyiAFxKdy4tH1CuD1rgud",
-    "size": 247333904,
+    "path": "avalanchego.avado.dnp.dappnode.eth_0.1.42.tar.xz",
+    "hash": "/ipfs/Qma3UD5pCHzkhWhBwCqKMa1h9pXPQrbq3sciuHBTPAHiTy",
+    "size": 246992208,
     "restart": "always",
     "environment": [
       "EXTRA_OPTS"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,11 @@
 version: '3.4'
 services:
   avalanchego.avado.dnp.dappnode.eth:
-    image: 'avalanchego.avado.dnp.dappnode.eth:0.1.41'
+    image: 'avalanchego.avado.dnp.dappnode.eth:0.1.42'
     build:
       context: ./build
       args:
-        - VERSION=v1.2.4
+        - VERSION=v1.3.0
     environment:
       - EXTRA_OPTS=--dynamic-public-ip=opendns
     volumes:

--- a/releases.json
+++ b/releases.json
@@ -200,5 +200,12 @@
     "uploadedTo": {
       "http://80.208.229.228:5001": "Thu, 18 Mar 2021 17:17:27 GMT"
     }
+  },
+  "0.1.42": {
+    "hash": "/ipfs/QmbbbkvG1zbeYcUFUADUUxECMrNkXhHJQjPJYJSEqnzjxa",
+    "type": "manifest",
+    "uploadedTo": {
+      "http://80.208.229.228:5001": "Fri, 26 Mar 2021 14:58:01 GMT"
+    }
   }
 }


### PR DESCRIPTION
Hash: `/ipfs/QmbbbkvG1zbeYcUFUADUUxECMrNkXhHJQjPJYJSEqnzjxa`

-------------------

Avado Avalanche v0.1.42 Release Notes;
The Avalanche version is updated to v1.3.0. It's urged that validators update their nodes as soon as possible. The changes in the upgrade go into effect at 10 AM EST, March 31st 2021.

Notable changes in Avalanche v1.3.0;

- Reduced C-chain gas cost from 470 nAVAX to 225 nAVAX.
- Removed C-chain gas refunds. This change adopts EIP-3298.
- Refactored C-chain verification to be cleaner when performing network upgrades.