### PR TITLE
v0.1.44

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,16 +1,16 @@
 {
   "name": "avalanchego.avado.dnp.dappnode.eth",
-  "version": "0.1.43",
-  "upstream": "v1.3.1",
+  "version": "0.1.44",
+  "upstream": "v1.3.2",
   "title": "Avalanche node",
   "description": "This is the Avalanche Mainnet node. Avalanche is an open-source platform for launching highly decentralized applications, new financial primitives, and new interoperable blockchains.",
   "avatar": "/ipfs/QmVwkdxaKfTiv6apuHjVP2ftzPahpcmwHpBNNdKp8QzZPn",
   "type": "service",
   "autoupdate": true,
   "image": {
-    "path": "avalanchego.avado.dnp.dappnode.eth_0.1.43.tar.xz",
-    "hash": "/ipfs/QmT8kNRABV2RX6bw7tFCuCtkTMcBN9pXjDLKq4etPcVPQK",
-    "size": 246729400,
+    "path": "avalanchego.avado.dnp.dappnode.eth_0.1.44.tar.xz",
+    "hash": "/ipfs/QmPbx6byYWnyrGJ4RbbesbnZhhXYBKWYZXAxnpxiWCX3gn",
+    "size": 251536704,
     "restart": "always",
     "environment": [
       "EXTRA_OPTS"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,11 @@
 version: '3.4'
 services:
   avalanchego.avado.dnp.dappnode.eth:
-    image: 'avalanchego.avado.dnp.dappnode.eth:0.1.43'
+    image: 'avalanchego.avado.dnp.dappnode.eth:0.1.44'
     build:
       context: ./build
       args:
-        - VERSION=v1.3.1
+        - VERSION=v1.3.2
     environment:
       - EXTRA_OPTS=--dynamic-public-ip=opendns
     volumes:

--- a/releases.json
+++ b/releases.json
@@ -214,5 +214,12 @@
     "uploadedTo": {
       "http://80.208.229.228:5001": "Tue, 30 Mar 2021 20:04:53 GMT"
     }
+  },
+  "0.1.44": {
+    "hash": "/ipfs/QmNYgpV8RrEhX1WaFz9gB7syNPL7EpxX5yfMAxp26PQxjD",
+    "type": "manifest",
+    "uploadedTo": {
+      "http://80.208.229.228:5001": "Wed, 14 Apr 2021 16:26:03 GMT"
+    }
   }
 }


### PR DESCRIPTION
Hash: /ipfs/QmNYgpV8RrEhX1WaFz9gB7syNPL7EpxX5yfMAxp26PQxjD

-----

Avado Avalanche v0.1.44 Release Notes;
The Avalanche version is updated to v1.3.2

Notable changes in AvalancheGo v1.3.2;

- Enforced a strict canonical format for C-chain blocks made prior to Apricot Phase 1. This ensures that modifications to the extra-data block field can not result in modifications to the chain state during bootstrapping.
- Changed the Keystore to ensure only encrypted values are sent over the IPC between avalanchego and plugin processes.
- Fixed delegation cap calculations to include updating the current delegation maximum before removing a delegator. This ensures that the delegation cap is always enforced.
- Fixed AVM's static API to be registered correctly on startup.
- Updated node uptime calculations to take network upgrades into account.