### PR TITLE
v0.1.45

### DIFF
--- a/build/files/supervisord.conf
+++ b/build/files/supervisord.conf
@@ -23,7 +23,7 @@ stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 
 [program:main]
-command=/usr/local/app/avalanchego --http-host=0.0.0.0 --http-tls-enabled=true --http-tls-cert-file=/etc/nginx/certs/server.crt --http-tls-key-file=/etc/nginx/certs/server.key --plugin-dir=/usr/local/app/plugins %(ENV_EXTRA_OPTS)s
+command=/usr/local/app/avalanchego --network-peer-list-size=10 --network-peer-list-gossip-size=20 --http-host=0.0.0.0 --http-tls-enabled=true --http-tls-cert-file=/etc/nginx/certs/server.crt --http-tls-key-file=/etc/nginx/certs/server.key --plugin-dir=/usr/local/app/plugins %(ENV_EXTRA_OPTS)s
 autostart=true
 autorestart=true
 stdout_logfile=/dev/fd/1

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,16 +1,16 @@
 {
   "name": "avalanchego.avado.dnp.dappnode.eth",
-  "version": "0.1.43",
-  "upstream": "v1.3.1",
+  "version": "0.1.45",
+  "upstream": "v1.4.3",
   "title": "Avalanche node",
   "description": "This is the Avalanche Mainnet node. Avalanche is an open-source platform for launching highly decentralized applications, new financial primitives, and new interoperable blockchains.",
   "avatar": "/ipfs/QmVwkdxaKfTiv6apuHjVP2ftzPahpcmwHpBNNdKp8QzZPn",
   "type": "service",
   "autoupdate": true,
   "image": {
-    "path": "avalanchego.avado.dnp.dappnode.eth_0.1.43.tar.xz",
-    "hash": "/ipfs/QmT8kNRABV2RX6bw7tFCuCtkTMcBN9pXjDLKq4etPcVPQK",
-    "size": 246729400,
+    "path": "avalanchego.avado.dnp.dappnode.eth_0.1.45.tar.xz",
+    "hash": "/ipfs/QmV6A48bmxkJM6dizDhCY7LhVGgfJagYiuFgd2qESEqcss",
+    "size": 252057284,
     "restart": "always",
     "environment": [
       "EXTRA_OPTS"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,11 @@
 version: '3.4'
 services:
   avalanchego.avado.dnp.dappnode.eth:
-    image: 'avalanchego.avado.dnp.dappnode.eth:0.1.43'
+    image: 'avalanchego.avado.dnp.dappnode.eth:0.1.45'
     build:
       context: ./build
       args:
-        - VERSION=v1.3.1
+        - VERSION=v1.4.3
     environment:
       - EXTRA_OPTS=--dynamic-public-ip=opendns
     volumes:

--- a/releases.json
+++ b/releases.json
@@ -214,5 +214,19 @@
     "uploadedTo": {
       "http://80.208.229.228:5001": "Tue, 30 Mar 2021 20:04:53 GMT"
     }
+  },
+  "0.1.44": {
+    "hash": "/ipfs/QmbLfJtbKgzBBGKso3FDwUeZ7FLKAMzZvGwT24xgjFb1ok",
+    "type": "manifest",
+    "uploadedTo": {
+      "http://80.208.229.228:5001": "Fri, 07 May 2021 16:05:24 GMT"
+    }
+  },
+  "0.1.45": {
+    "hash": "/ipfs/QmXDE8k9i2cRn4igsmPHNR2qsngouh4FVh9NbaSsjtktY2",
+    "type": "manifest",
+    "uploadedTo": {
+      "http://80.208.229.228:5001": "Fri, 14 May 2021 13:00:47 GMT"
+    }
   }
 }


### PR DESCRIPTION
Hash: `/ipfs/QmXDE8k9i2cRn4igsmPHNR2qsngouh4FVh9NbaSsjtktY2`

------

Avado Avalanche v0.1.45 Release Notes;
The Avalanche version is updated to v1.4.3. This update is backwards compatible. It is optional, but encouraged. The patch includes bug fixes, updated uptime monitoring, and performance improvements.

Notable changes in Avalanche v1.4.3;
- Fixed benched message handling that could cause a node to be unable to progress during bootstrapping. This was typically experienced when the node would fail to transition to normal execution as it was finishing bootstrapping.
- Fixed a non-deterministic bug in the C-Chain codebase that could cause nodes that receive a lot of transaction broadcast requests to temporarily stop producing blocks until they processes a block produced by another node.