### PR TITLE
v0.1.46

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,16 +1,16 @@
 {
   "name": "avalanchego.avado.dnp.dappnode.eth",
-  "version": "0.1.45",
-  "upstream": "v1.4.3",
+  "version": "0.1.46",
+  "upstream": "v1.4.4",
   "title": "Avalanche node",
   "description": "This is the Avalanche Mainnet node. Avalanche is an open-source platform for launching highly decentralized applications, new financial primitives, and new interoperable blockchains.",
   "avatar": "/ipfs/QmVwkdxaKfTiv6apuHjVP2ftzPahpcmwHpBNNdKp8QzZPn",
   "type": "service",
   "autoupdate": true,
   "image": {
-    "path": "avalanchego.avado.dnp.dappnode.eth_0.1.45.tar.xz",
-    "hash": "/ipfs/QmV6A48bmxkJM6dizDhCY7LhVGgfJagYiuFgd2qESEqcss",
-    "size": 252057284,
+    "path": "avalanchego.avado.dnp.dappnode.eth_0.1.46.tar.xz",
+    "hash": "/ipfs/Qma5wb8M3ZZYM1DuBoHdL5wi8s4VfcFVHMBNKSfyUvZQiF",
+    "size": 241147648,
     "restart": "always",
     "environment": [
       "EXTRA_OPTS"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,11 @@
 version: '3.4'
 services:
   avalanchego.avado.dnp.dappnode.eth:
-    image: 'avalanchego.avado.dnp.dappnode.eth:0.1.45'
+    image: 'avalanchego.avado.dnp.dappnode.eth:0.1.46'
     build:
       context: ./build
       args:
-        - VERSION=v1.4.3
+        - VERSION=v1.4.4
     environment:
       - EXTRA_OPTS=--dynamic-public-ip=opendns
     volumes:

--- a/releases.json
+++ b/releases.json
@@ -228,5 +228,12 @@
     "uploadedTo": {
       "http://80.208.229.228:5001": "Fri, 14 May 2021 13:00:47 GMT"
     }
+  },
+  "0.1.46": {
+    "hash": "/ipfs/QmbS5PZDje8VMG3z8JLzs9p29CpS8SfHfFvTqMvGLCQjpt",
+    "type": "manifest",
+    "uploadedTo": {
+      "http://80.208.229.228:5001": "Thu, 20 May 2021 20:41:13 GMT"
+    }
   }
 }


### PR DESCRIPTION
Hash: `/ipfs/QmbS5PZDje8VMG3z8JLzs9p29CpS8SfHfFvTqMvGLCQjpt`

--------

Avado Avalanche v0.1.46 Release Notes;
The Avalanche version is updated to v1.4.4. The patch includes bug fixes and performance improvements that aim to optimize the upcoming db-upgrade release.