### PR TITLE
v0.1.47

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,16 +1,16 @@
 {
   "name": "avalanchego.avado.dnp.dappnode.eth",
-  "version": "0.1.46",
-  "upstream": "v1.4.4",
+  "version": "0.1.47",
+  "upstream": "v1.4.5",
   "title": "Avalanche node",
   "description": "This is the Avalanche Mainnet node. Avalanche is an open-source platform for launching highly decentralized applications, new financial primitives, and new interoperable blockchains.",
   "avatar": "/ipfs/QmVwkdxaKfTiv6apuHjVP2ftzPahpcmwHpBNNdKp8QzZPn",
   "type": "service",
   "autoupdate": true,
   "image": {
-    "path": "avalanchego.avado.dnp.dappnode.eth_0.1.46.tar.xz",
-    "hash": "/ipfs/Qma5wb8M3ZZYM1DuBoHdL5wi8s4VfcFVHMBNKSfyUvZQiF",
-    "size": 241147648,
+    "path": "avalanchego.avado.dnp.dappnode.eth_0.1.47.tar.xz",
+    "hash": "/ipfs/QmVR95ymb96EWpR3JCPWuKqV3PwQrXi68cMNzZrh5ANChE",
+    "size": 290354996,
     "restart": "always",
     "environment": [
       "EXTRA_OPTS"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,11 @@
 version: '3.4'
 services:
   avalanchego.avado.dnp.dappnode.eth:
-    image: 'avalanchego.avado.dnp.dappnode.eth:0.1.46'
+    image: 'avalanchego.avado.dnp.dappnode.eth:0.1.47'
     build:
       context: ./build
       args:
-        - VERSION=v1.4.4
+        - VERSION=v1.4.5
     environment:
       - EXTRA_OPTS=--dynamic-public-ip=opendns
     volumes:

--- a/releases.json
+++ b/releases.json
@@ -235,5 +235,12 @@
     "uploadedTo": {
       "http://80.208.229.228:5001": "Thu, 20 May 2021 20:41:13 GMT"
     }
+  },
+  "0.1.47": {
+    "hash": "/ipfs/QmaBkFYrH5HV8LBF9QWuhRAoa9HWEs5RwcttmzB7JpY4qC",
+    "type": "manifest",
+    "uploadedTo": {
+      "http://80.208.229.228:5001": "Sat, 22 May 2021 20:23:34 GMT"
+    }
   }
 }


### PR DESCRIPTION
Hash: `/ipfs/QmaBkFYrH5HV8LBF9QWuhRAoa9HWEs5RwcttmzB7JpY4qC`

----

Avado Avalanche v0.1.47 Release Notes;
The Avalanche version is updated to v1.4.5. The patch includes significant performance improvements and numerous other updates. This version contains a database upgrade which yields ~90% reduction in read I/O on a Mainnet validator. It's anticipated that nodes upgraded to >= v1.4.5 will consume less CPU and perform many fewer disk reads once the migration has been completed. These changes will also significantly improve P-Chain decision latency.

