### PR TITLE
Update to AvalancheGo null

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "avalanchego.avado.dnp.dappnode.eth",
-  "version": "0.1.100",
-  "upstream": "v1.14.2",
+  "version": "0.1.101",
+  "upstream": "null",
   "title": "Avalanche node",
   "description": "This is the Avalanche Mainnet node. Avalanche is an open-source platform for launching highly decentralized applications, new financial primitives, and new interoperable blockchains.",
   "avatar": "/ipfs/QmVwkdxaKfTiv6apuHjVP2ftzPahpcmwHpBNNdKp8QzZPn",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,11 @@
 version: '3.4'
 services:
   avalanchego.avado.dnp.dappnode.eth:
-    image: 'avalanchego.avado.dnp.dappnode.eth:0.1.100'
+    image: 'avalanchego.avado.dnp.dappnode.eth:0.1.101'
     build:
       context: ./build
       args:
-        - VERSION=v1.14.2
+        - VERSION=null
     environment:
       - EXTRA_OPTS=--dynamic-public-ip=opendns
     volumes:


### PR DESCRIPTION
## Automated Version Update

This PR updates the package to use the latest AvalancheGo release.

**Changes:**
- Package version: `v1.14.2`
  → `0.1.101`
- Upstream version: `v1.14.2`
  → `null`

**Release Notes:**
https://github.com/ava-labs/avalanchego/releases/tag/null

cc @flisko